### PR TITLE
Updated endpoint URL for wallet_fetchPermissions

### DIFF
--- a/docs/pages/guides/spend-permissions/api-reference/wallet-fetchpermissions.mdx
+++ b/docs/pages/guides/spend-permissions/api-reference/wallet-fetchpermissions.mdx
@@ -7,7 +7,7 @@ Excludes permissions that have expired or been revoked.
 
 #### Schema
 
-**Endpoint:** `https://chain-proxy.wallet.coinbase.com`
+**Endpoint:** `https://rpc.wallet.coinbase.com`
 
 ```typescript
 type FetchPermissionsRequest = {
@@ -41,7 +41,7 @@ type FetchPermissionsResultItem = {
     start: number; // unix seconds
     end: number; // unix seconds
     salt: string; // base 10 numeric string
-    extraData: string // hex
+    extraData; string // hex
   };
 }
 ```

--- a/docs/pages/guides/spend-permissions/api-reference/wallet-fetchpermissions.mdx
+++ b/docs/pages/guides/spend-permissions/api-reference/wallet-fetchpermissions.mdx
@@ -41,7 +41,7 @@ type FetchPermissionsResultItem = {
     start: number; // unix seconds
     end: number; // unix seconds
     salt: string; // base 10 numeric string
-    extraData; string // hex
+    extraData: string; // hex
   };
 }
 ```


### PR DESCRIPTION
rpc.wallet.coinbase.com is live! This URL is a bit clearer in naming than the old one and will be more commonly used in the future.