### PR TITLE
Note for strict ordering

### DIFF
--- a/docs/pages/guides/spend-permissions/api-reference/spendpermissionmanager.mdx
+++ b/docs/pages/guides/spend-permissions/api-reference/spendpermissionmanager.mdx
@@ -1,3 +1,5 @@
+import { Callout } from 'vocs/components';
+
 # `SpendPermissionManager.sol` smart contract
 
 The open-source contracts repository is [here](https://github.com/coinbase/spend-permissions).
@@ -7,6 +9,10 @@ The open-source contracts repository is [here](https://github.com/coinbase/spend
 #### `SpendPermission`
 
 Defines the complete parameters of a spend permission.
+
+<Callout type="warning" >
+The fields of the `SpendPermission` structure must be strictly ordered as defined below. 
+</Callout>
 
 | Field       | Type      | Description                                                                                |
 | ----------- | --------- | ------------------------------------------------------------------------------------------ |


### PR DESCRIPTION
Added a small note for ordering of paramters for spend permissions
<img width="728" alt="Screenshot 2024-11-15 at 11 32 43 AM" src="https://github.com/user-attachments/assets/9de16b54-944f-48a5-89b9-d8b6b3e3ae91">

