### PR TITLE
Add note about Smart Wallet gas limits to FAQ

### DIFF
--- a/docs/pages/FAQ.mdx
+++ b/docs/pages/FAQ.mdx
@@ -49,3 +49,9 @@ This means users no longer have to deal with passwords or recovery phrases. Inst
 ## What happens if a user loses their passkey? 
 
 Every Smart Wallet supports multiple owners, and our client will soon allow users to add a backup recovery key for the unlikely case they lose their passkey.
+
+## Are there different gas limitations when using Smart Wallet?
+
+Smart Wallet transactions have additional gas overhead and require somewhat more conservative gas estimations. This means the maximum gas that can be consumed by a 
+Smart Wallet transaction (user operation) is currently capped at 18 million gas, much lower than the block gas limit itself. It will be possible to increase this 
+limit as L2 throughput continues to scale.


### PR DESCRIPTION
We recently had a lengthy conversation with a partner whose app uses almost 25 million gas per transaction about the limitations of maximum transaction gas when using smart wallet. These expensive transactions are possible when using an EOA, but not when users have a smart wallet. I learned through investigating that any given bundle is capped at 18 million base gas, to accommodate 4337 meta operation gas (verification, entrypoint calls, postOp steps if using a paymaster, etc.) and conservative gas estimation to avoid the bundle blowing the block gas limit and placing the burden of this failed txn gas on the bundler.

As a developer, this is something that would be very important for me to understand when building an application that supports smart wallet! I think we should add it at least to the FAQs so it's more searchable.