### PR TITLE
feat(BW-716): renamed wallet_fetchPermissions to coinbase_fetchPermissions

### DIFF
--- a/docs/pages/guides/spend-permissions/api-reference/coinbase-fetchpermissions.mdx
+++ b/docs/pages/guides/spend-permissions/api-reference/coinbase-fetchpermissions.mdx
@@ -1,6 +1,6 @@
 ## Coinbase Wallet API
 
-### `wallet_fetchPermissions`
+### `coinbase_fetchPermissions`
 
 A utility API endpoint for recalling permissions previously granted for a specific user.
 Excludes permissions that have expired or been revoked.

--- a/vocs.config.tsx
+++ b/vocs.config.tsx
@@ -125,8 +125,8 @@ export default defineConfig({
                   link: "/guides/spend-permissions/api-reference/spendpermissionmanager",
                 },
                 {
-                  text: "wallet_fetchPermissions",
-                  link: "/guides/spend-permissions/api-reference/wallet-fetchpermissions",
+                  text: "coinbase_fetchPermissions",
+                  link: "/guides/spend-permissions/api-reference/coinbase-fetchpermissions",
                 },
                 {
                   text: "Client Resources",


### PR DESCRIPTION
We decided to rename this due to it being a Coinbase-specific RPC. Tested here:
```sh
curl --location 'https://rpc.wallet.coinbase.com' \
--header 'Content-Type: application/json' \
--data '{
    "jsonrpc":"2.0",
    "method":"coinbase_fetchPermissions",
    "params":[{"account":"0x9b79ab23d2c1c2976e5df085164d874f4df9089e","chainId":"0x14A34","spender":"0x4E760F8FDfc54B8adFDd8D7c22Ff721a09051145"}],
    "id":1
}' | jq
```