### PR TITLE
Remove references to keys-dev, devs can use keys.coinbase.com

### DIFF
--- a/docs/pages/guides/spend-permissions/quick-start.mdx
+++ b/docs/pages/guides/spend-permissions/quick-start.mdx
@@ -79,15 +79,11 @@ export async function getSpenderWalletClient() {
 
 ### Configure the Smart Wallet URL
 
-In `app/providers.tsx`, update the value of `keysUrl` to be `"https://keys-dev.coinbase.com/connect"`.
-This will point your app to connect to our public dev environment for smart wallet connections.
-
-We also want to point our chain id to Base Sepolia testnet by setting replacing all instances of `base`
-with `baseSepolia` in this file (including the import).
+In `app/providers.tsx`, update the chain configuration to use Base Sepolia testnet by replacing all instances of `base` with `baseSepolia` in this file (including the import).
 
 Your config in `app/providers.tsx` should now look like this:
 
-```
+```ts
 const config = createConfig({
   chains: [baseSepolia],
   connectors: [
@@ -96,8 +92,6 @@ const config = createConfig({
       preference: process.env.NEXT_PUBLIC_ONCHAINKIT_WALLET_CONFIG as
         | "smartWalletOnly"
         | "all",
-      // @ts-ignore
-      keysUrl: "https://keys-dev.coinbase.com/connect"
     }),
   ],
   storage: createStorage({


### PR DESCRIPTION
keys-dev was used to expose the feature before contracts were fully audited. For testing purposes, devs only need use testnet chains, not a test environment