### PR TITLE
Update docs for keysurl

### DIFF
--- a/docs/pages/guides/spend-permissions/quick-start.mdx
+++ b/docs/pages/guides/spend-permissions/quick-start.mdx
@@ -79,7 +79,13 @@ export async function getSpenderWalletClient() {
 
 ### Configure the Smart Wallet URL
 
-In `app/providers.tsx`, update the chain configuration to use Base Sepolia testnet by replacing all instances of `base` with `baseSepolia` in this file (including the import).
+In `app/providers.tsx`, update the value of `keysUrl` based on your environment:
+
+- For testnets: `"https://keys-dev.coinbase.com/connect"`
+- For mainnets: Leave `keysUrl` undefined (defaults to keys.coinbase.com)
+
+We also want to point our chain id to Base Sepolia testnet by setting replacing all instances of `base`
+with `baseSepolia` in this file (including the import).
 
 Your config in `app/providers.tsx` should now look like this:
 
@@ -92,6 +98,8 @@ const config = createConfig({
       preference: process.env.NEXT_PUBLIC_ONCHAINKIT_WALLET_CONFIG as
         | "smartWalletOnly"
         | "all",
+      // @ts-ignore
+      keysUrl: "https://keys-dev.coinbase.com/connect"
     }),
   ],
   storage: createStorage({

--- a/docs/pages/guides/spend-permissions/quick-start.mdx
+++ b/docs/pages/guides/spend-permissions/quick-start.mdx
@@ -79,15 +79,16 @@ export async function getSpenderWalletClient() {
 
 ### Configure the Smart Wallet URL
 
-In `app/providers.tsx`, update the value of `keysUrl` based on your environment:
+In `app/providers.tsx`, update your configuration based on your environment:
 
-- For testnets: `"https://keys-dev.coinbase.com/connect"`
-- For mainnets: Leave `keysUrl` undefined (defaults to keys.coinbase.com)
+- For testnets:
+  - Set `keysUrl: "https://keys-dev.coinbase.com/connect"`
+  - Replace all instances of `base` with `baseSepolia` (including the import)
+- For mainnets:
+  - Leave `keysUrl` undefined (defaults to keys.coinbase.com)
+  - Keep the default `base` chain from the template
 
-We also want to point our chain id to Base Sepolia testnet by setting replacing all instances of `base`
-with `baseSepolia` in this file (including the import).
-
-Your config in `app/providers.tsx` should now look like this:
+Your config in `app/providers.tsx` should look like this for testnet:
 
 ```ts
 const config = createConfig({


### PR DESCRIPTION
In cases where you need to do an account change to add the permission manager - the user's wallet must be on the right keysUrl:

Mainnet requests: Must be on keys.coinbase.com
Testnet requests: must be on keys-dev.coinbase.com

Newly created accounts don't share this restriction.