### PR TITLE
docs: typo fix Update using-onchain-app-template.mdx

### DIFF
--- a/docs/pages/guides/create-app/using-onchain-app-template.mdx
+++ b/docs/pages/guides/create-app/using-onchain-app-template.mdx
@@ -16,7 +16,7 @@ To ensure all components work seamlessly, set the following environment variable
 
 - `NEXT_PUBLIC_WC_PROJECT_ID`: Create a project at [Wallet Connect](https://cloud.walletconnect.com) to obtain this.
 
-Add theses to you `.env` file:
+Add these to your `.env` file:
 
 ```bash
 NEXT_PUBLIC_CDP_API_KEY=ADD_YOUR_API_KEY_HERE


### PR DESCRIPTION
The typo is in the following line:

```bash
Add theses to you `.env` file:
```

Corrected version is:

```bash
Add these to your `.env` file:
```